### PR TITLE
chore(ci): remove deprecated delete-tag-and-release action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,11 +39,11 @@ jobs:
       - uses: actions/checkout@v4
         if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
 
-      - uses: dev-drprasad/delete-tag-and-release@v1.1
+      - name: Delete existing "latest" release and tag
         if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
-        with:
-          delete_release: true
-          tag_name: latest
+        run: |
+          set -euo pipefail
+          gh release delete latest --cleanup-tag --yes || true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Replace dev-drprasad/delete-tag-and-release (unmaintained, archived) with a direct gh CLI call, as recommended by the maintainer.

https://github.com/dev-drprasad/delete-tag-and-release/commit/6c843f0f78b0666910a98f4f445d09e3a3b32719